### PR TITLE
[WIP] Preserve the type for recovery-expr when possible

### DIFF
--- a/clang/include/clang/AST/Expr.h
+++ b/clang/include/clang/AST/Expr.h
@@ -6052,8 +6052,9 @@ public:
 class RecoveryExpr final : public Expr,
                            private llvm::TrailingObjects<RecoveryExpr, Expr *> {
 public:
-  static RecoveryExpr *Create(ASTContext &Ctx, SourceLocation BeginLoc,
-                              SourceLocation EndLoc, ArrayRef<Expr *> SubExprs);
+  static RecoveryExpr *Create(ASTContext &Ctx, QualType T,
+                              SourceLocation BeginLoc, SourceLocation EndLoc,
+                              ArrayRef<Expr *> SubExprs);
   static RecoveryExpr *CreateEmpty(ASTContext &Ctx, unsigned NumSubExprs);
 
   ArrayRef<Expr *> subExpressions() {
@@ -6078,7 +6079,7 @@ public:
   }
 
 private:
-  RecoveryExpr(ASTContext &Ctx, SourceLocation BeginLoc, SourceLocation EndLoc,
+  RecoveryExpr(ASTContext &Ctx, QualType T, SourceLocation BeginLoc, SourceLocation EndLoc,
                ArrayRef<Expr *> SubExprs);
   RecoveryExpr(EmptyShell Empty, unsigned NumSubExprs)
       : Expr(RecoveryExprClass, Empty), NumExprs(NumSubExprs) {}

--- a/clang/include/clang/Basic/LangOptions.def
+++ b/clang/include/clang/Basic/LangOptions.def
@@ -149,6 +149,7 @@ LANGOPT(RelaxedTemplateTemplateArgs, 1, 0, "C++17 relaxed matching of template t
 LANGOPT(DoubleSquareBracketAttributes, 1, 0, "'[[]]' attributes extension for all language standard modes")
 
 COMPATIBLE_LANGOPT(RecoveryAST, 1, CPlusPlus, "Preserve expressions in AST when encountering errors")
+COMPATIBLE_LANGOPT(RecoveryASTType, 1, 0, "Preserve the type in recovery expressions")
 
 BENIGN_LANGOPT(ThreadsafeStatics , 1, 1, "thread-safe static initializers")
 LANGOPT(POSIXThreads      , 1, 0, "POSIX thread support")

--- a/clang/include/clang/Driver/CC1Options.td
+++ b/clang/include/clang/Driver/CC1Options.td
@@ -569,6 +569,10 @@ def frecovery_ast : Flag<["-"], "frecovery-ast">,
   HelpText<"Preserve expressions in AST rather than dropping them when "
            "encountering semantic errors">;
 def fno_recovery_ast : Flag<["-"], "fno-recovery-ast">;
+def frecovery_ast_type : Flag<["-"], "frecovery-ast-type">,
+  HelpText<"Preserve the type for recovery expressions when possible "
+          "(experimental) ">;
+def fno_recovery_ast_type : Flag<["-"], "fno-recovery-ast-type">;
 
 let Group = Action_Group in {
 

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -3887,7 +3887,8 @@ public:
 
   /// Attempts to produce a RecoveryExpr after some AST node cannot be created.
   ExprResult CreateRecoveryExpr(SourceLocation Begin, SourceLocation End,
-                                ArrayRef<Expr *> SubExprs);
+                                ArrayRef<Expr *> SubExprs,
+                                QualType T = QualType());
 
   ObjCInterfaceDecl *getObjCInterfaceDecl(IdentifierInfo *&Id,
                                           SourceLocation IdLoc,

--- a/clang/lib/AST/ComputeDependence.cpp
+++ b/clang/lib/AST/ComputeDependence.cpp
@@ -487,7 +487,8 @@ ExprDependence clang::computeDependence(DeclRefExpr *E, const ASTContext &Ctx) {
 ExprDependence clang::computeDependence(RecoveryExpr *E) {
   // FIXME: drop type+value+instantiation once Error is sufficient to suppress
   // bogus dianostics.
-  auto D = ExprDependence::TypeValueInstantiation | ExprDependence::Error;
+  // E->getType()
+  auto D = toExprDependence(E->getType()->getDependence()) | ExprDependence::Error;
   for (auto *S : E->subExpressions())
     D |= S->getDependence();
   return D;

--- a/clang/lib/AST/Expr.cpp
+++ b/clang/lib/AST/Expr.cpp
@@ -4666,7 +4666,7 @@ RecoveryExpr *RecoveryExpr::Create(ASTContext &Ctx, QualType T, SourceLocation B
                                    ArrayRef<Expr *> SubExprs) {
   void *Mem = Ctx.Allocate(totalSizeToAlloc<Expr *>(SubExprs.size()),
                            alignof(RecoveryExpr));
-   if (T.isNull())
+  if (T.isNull())
     // We don't know the concrete type, fallback to dependent type.
     T = Ctx.DependentTy;
   return new (Mem) RecoveryExpr(Ctx, T, BeginLoc, EndLoc, SubExprs);

--- a/clang/lib/AST/Expr.cpp
+++ b/clang/lib/AST/Expr.cpp
@@ -3306,7 +3306,7 @@ bool Expr::HasSideEffects(const ASTContext &Ctx,
   if (!IncludePossibleEffects && getExprLoc().isMacroID())
     return false;
 
-  if (isInstantiationDependent())
+  if (isInstantiationDependent() || containsErrors())
     return IncludePossibleEffects;
 
   switch (getStmtClass()) {

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -2891,6 +2891,8 @@ static void ParseLangArgs(LangOptions &Opts, ArgList &Args, InputKind IK,
     Diags.Report(diag::warn_fe_concepts_ts_flag);
   Opts.RecoveryAST =
       Args.hasFlag(OPT_frecovery_ast, OPT_fno_recovery_ast, Opts.CPlusPlus);
+  Opts.RecoveryASTType =
+      Args.hasFlag(OPT_frecovery_ast_type, OPT_fno_recovery_ast_type, false);
   Opts.HeinousExtensions = Args.hasArg(OPT_fheinous_gnu_extensions);
   Opts.AccessControl = !Args.hasArg(OPT_fno_access_control);
   Opts.ElideConstructors = !Args.hasArg(OPT_fno_elide_constructors);

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -2892,7 +2892,7 @@ static void ParseLangArgs(LangOptions &Opts, ArgList &Args, InputKind IK,
   Opts.RecoveryAST =
       Args.hasFlag(OPT_frecovery_ast, OPT_fno_recovery_ast, Opts.CPlusPlus);
   Opts.RecoveryASTType =
-      Args.hasFlag(OPT_frecovery_ast_type, OPT_fno_recovery_ast_type, false);
+      Args.hasFlag(OPT_frecovery_ast_type, OPT_fno_recovery_ast_type, true);
   Opts.HeinousExtensions = Args.hasArg(OPT_fheinous_gnu_extensions);
   Opts.AccessControl = !Args.hasArg(OPT_fno_access_control);
   Opts.ElideConstructors = !Args.hasArg(OPT_fno_elide_constructors);

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -16424,7 +16424,7 @@ FieldDecl *Sema::CheckFieldDecl(DeclarationName Name, QualType T,
   }
 
   QualType EltTy = Context.getBaseElementType(T);
-  if (!EltTy->isDependentType()) {
+  if (!EltTy->isDependentType() && !EltTy->containsErrors()) {
     if (RequireCompleteSizedType(Loc, EltTy,
                                  diag::err_field_incomplete_or_sizeless)) {
       // Fields of incomplete type force their record to be invalid.

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -6154,8 +6154,28 @@ ExprResult Sema::ActOnCallExpr(Scope *Scope, Expr *Fn, SourceLocation LParenLoc,
                                Expr *ExecConfig) {
   ExprResult Call =
       BuildCallExpr(Scope, Fn, LParenLoc, ArgExprs, RParenLoc, ExecConfig);
-  if (Call.isInvalid())
-    return Call;
+  if (Call.isInvalid()) {
+    QualType TargetType;
+    if (auto *ULE = dyn_cast<UnresolvedLookupExpr>(Fn)) {
+      for (const auto *D : ULE->decls()) {
+        if (const auto *FD = dyn_cast<FunctionDecl>(D)) {
+          if (TargetType.isNull())
+            TargetType = FD->getCallResultType();
+          else if (TargetType != FD->getCallResultType()) {
+            TargetType = QualType();
+            break;
+          }
+        }
+      }
+    }
+
+    if (TargetType.isNull()
+        || TargetType->isUndeducedAutoType())
+      TargetType = Context.DependentTy;
+    std::vector<Expr *> Args = {ArgExprs.begin(), ArgExprs.end()};
+    Args.insert(Args.begin(), Fn);
+    return CreateRecoveryExpr(Fn->getBeginLoc(), RParenLoc, Args, TargetType);
+  }
 
   // Diagnose uses of the C++20 "ADL-only template-id call" feature in earlier
   // language modes.
@@ -18945,7 +18965,7 @@ bool Sema::IsDependentFunctionNameExpr(Expr *E) {
 }
 
 ExprResult Sema::CreateRecoveryExpr(SourceLocation Begin, SourceLocation End,
-                                    ArrayRef<Expr *> SubExprs) {
+                                    ArrayRef<Expr *> SubExprs, QualType T) {
   // FIXME: enable it for C++, RecoveryExpr is type-dependent to suppress
   // bogus diagnostics and this trick does not work in C.
   // FIXME: use containsErrors() to suppress unwanted diags in C.
@@ -18955,5 +18975,5 @@ ExprResult Sema::CreateRecoveryExpr(SourceLocation Begin, SourceLocation End,
   if (isSFINAEContext())
     return ExprError();
 
-  return RecoveryExpr::Create(Context, Begin, End, SubExprs);
+  return RecoveryExpr::Create(Context, T, Begin, End, SubExprs);
 }

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -18975,5 +18975,8 @@ ExprResult Sema::CreateRecoveryExpr(SourceLocation Begin, SourceLocation End,
   if (isSFINAEContext())
     return ExprError();
 
+  if (T.isNull() || !Context.getLangOpts().RecoveryASTType)
+    // We don't know the concrete type, fallback to dependent type.
+    T = Context.DependentTy;
   return RecoveryExpr::Create(Context, T, Begin, End, SubExprs);
 }

--- a/clang/test/AST/ast-dump-recovery.cpp
+++ b/clang/test/AST/ast-dump-recovery.cpp
@@ -4,9 +4,10 @@
 int some_func(int *);
 
 // CHECK:     VarDecl {{.*}} invalid_call
-// CHECK-NEXT:`-RecoveryExpr {{.*}} contains-errors
-// CHECK-NEXT:  |-UnresolvedLookupExpr {{.*}} 'some_func'
-// CHECK-NEXT:  `-IntegerLiteral {{.*}} 123
+// CHECK-NEXT: `-ImplicitCastExpr {{.*}} 'int' contains-errors
+// CHECK-NEXT:  `-RecoveryExpr {{.*}} 'int' contains-errors
+// CHECK-NEXT:    |-UnresolvedLookupExpr {{.*}} 'some_func'
+// CHECK-NEXT:    `-IntegerLiteral {{.*}} 123
 // DISABLED-NOT: -RecoveryExpr {{.*}} contains-errors
 int invalid_call = some_func(123);
 
@@ -14,14 +15,15 @@ int ambig_func(double);
 int ambig_func(float);
 
 // CHECK:     VarDecl {{.*}} ambig_call
-// CHECK-NEXT:`-RecoveryExpr {{.*}} contains-errors
-// CHECK-NEXT:  |-UnresolvedLookupExpr {{.*}} 'ambig_func'
-// CHECK-NEXT:  `-IntegerLiteral {{.*}} 123
+// CHECK-NEXT: `-ImplicitCastExpr {{.*}} 'int' contains-errors
+// CHECK-NEXT:  `-RecoveryExpr {{.*}} 'int' contains-errors
+// CHECK-NEXT:    |-UnresolvedLookupExpr {{.*}} 'ambig_func'
+// CHECK-NEXT:    `-IntegerLiteral {{.*}} 123
 // DISABLED-NOT: -RecoveryExpr {{.*}} contains-errors
 int ambig_call = ambig_func(123);
 
 // CHECK:     VarDecl {{.*}} unresolved_call1
-// CHECK-NEXT:`-RecoveryExpr {{.*}} contains-errors
+// CHECK-NEXT:`-RecoveryExpr {{.*}} '<dependent type>' contains-errors
 // CHECK-NEXT:  `-UnresolvedLookupExpr {{.*}} 'bar'
 // DISABLED-NOT: -RecoveryExpr {{.*}} contains-errors
 int unresolved_call1 = bar();

--- a/clang/test/Index/getcursor-recovery.cpp
+++ b/clang/test/Index/getcursor-recovery.cpp
@@ -2,15 +2,24 @@ int foo(int, int);
 int foo(int, double);
 int x;
 
-void testTypedRecoveryExpr() {
-  // Inner foo() is a RecoveryExpr, outer foo() is an overloaded call.
-  foo(x, foo(x));
+void testTypedRecoveryExpr1() {
+  // Inner bar() is a RecoveryExpr, outer foo() is an overloaded call.
+  foo(x, bar(x));
 }
 // RUN: c-index-test -cursor-at=%s:7:3 %s -Xclang -frecovery-ast | FileCheck -check-prefix=OUTER-FOO %s
 // OUTER-FOO: OverloadedDeclRef=foo[2:5, 1:5]
 // RUN: c-index-test -cursor-at=%s:7:7 %s -Xclang -frecovery-ast | FileCheck -check-prefix=OUTER-X %s
 // OUTER-X: DeclRefExpr=x:3:5
 // RUN: c-index-test -cursor-at=%s:7:10 %s -Xclang -frecovery-ast | FileCheck -check-prefix=INNER-FOO %s
-// INNER-FOO: OverloadedDeclRef=foo[2:5, 1:5]
+// INNER-FOO: OverloadedDeclRef=bar
 // RUN: c-index-test -cursor-at=%s:7:14 %s -Xclang -frecovery-ast | FileCheck -check-prefix=INNER-X %s
 // INNER-X: DeclRefExpr=x:3:5
+
+void testTypedRecoveryExpr2() {
+  // Inner foo() is a RecoveryExpr (with int type), outer foo() is a "foo(int, int)" call.
+  foo(x, foo(x));
+}
+// RUN: c-index-test -cursor-at=%s:20:3 %s -Xclang -frecovery-ast | FileCheck -check-prefix=TEST2-OUTER %s
+// TEST2-OUTER: DeclRefExpr=foo:1:5
+// RUN: c-index-test -cursor-at=%s:20:10 %s -Xclang -frecovery-ast | FileCheck -check-prefix=TEST2-INNER %s
+// TEST2-INNER: OverloadedDeclRef=foo[2:5, 1:5]

--- a/clang/test/SemaCXX/cxx1z-copy-omission.cpp
+++ b/clang/test/SemaCXX/cxx1z-copy-omission.cpp
@@ -97,15 +97,17 @@ void test_expressions(bool b) {
   // We must check for a complete type for every materialized temporary. (Note
   // that in the special case of the top level of a decltype, no temporary is
   // materialized.)
+  // FIXME: get rid of the "incomplete type" diagnostic below.
   make_incomplete(); // expected-error {{incomplete}}
-  make_incomplete().a; // expected-error {{incomplete}}
+  make_incomplete().a; // expected-error {{incomplete}} expected-error {{member access into incomplete type}}
   make_incomplete().*(int Incomplete::*)nullptr; // expected-error {{incomplete}}
-  dynamic_cast<Incomplete&&>(make_incomplete()); // expected-error {{incomplete}}
+  dynamic_cast<Incomplete&&>(make_incomplete()); // expected-error {{incomplete}} expected-error {{an incomplete type}}
   const_cast<Incomplete&&>(make_incomplete()); // expected-error {{incomplete}}
 
   sizeof(Indestructible{}); // expected-error {{deleted}}
+  // FIXME: get rid of the "invalid application" diagnostics.
   sizeof(make_indestructible()); // expected-error {{deleted}}
-  sizeof(make_incomplete()); // expected-error {{incomplete}}
+  sizeof(make_incomplete()); // expected-error {{incomplete}} expected-error {{invalid application of 'sizeof' to an incomplete type}}
   typeid(Indestructible{}); // expected-error {{deleted}}
   typeid(make_indestructible()); // expected-error {{deleted}} \
                                  // expected-error {{need to include <typeinfo>}}

--- a/clang/test/SemaCXX/enable_if.cpp
+++ b/clang/test/SemaCXX/enable_if.cpp
@@ -415,7 +415,7 @@ static_assert(templated<1>() == 1, "");
 template <int N> constexpr int callTemplated() { return templated<N>(); }
 
 constexpr int B = 10 + // the carat for the error should be pointing to the problematic call (on the next line), not here.
-    callTemplated<0>(); // expected-error{{initialized by a constant expression}} expected-error@-3{{no matching function for call to 'templated'}} expected-note{{in instantiation of function template}} expected-note@-10{{candidate disabled}}
+    callTemplated<0>(); // expected-error@-1{{initialized by a constant expression}} expected-error@-3{{no matching function for call to 'templated'}} expected-note{{in instantiation of function template}} expected-note@-10{{candidate disabled}} expected-note {{in call to 'callTemplated()'}} expected-note@-3 {{subexpression not valid in a constant expression}}
 static_assert(callTemplated<1>() == 1, "");
 }
 

--- a/clang/test/SemaCXX/recovery-type-cxx.cpp
+++ b/clang/test/SemaCXX/recovery-type-cxx.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple=x86_64-unknown-unknown -frecovery-ast -frecovery-ast-type -std=c++11 -o - %s -fsyntax-only -verify
+// RUN: %clang_cc1 -triple=x86_64-unknown-unknown -frecovery-ast -frecovery-ast-type -o - %s -fsyntax-only -verify
 
 namespace NoCrash{
 struct Indestructible {
@@ -11,4 +11,12 @@ Indestructible make_indestructible();
 void test() {
   int s = sizeof(make_indestructible()); // expected-error {{deleted}}
 }
+}
+
+namespace {
+void foo(); // expected-note {{requires 0 arguments}}
+class Y {
+  // no "field has incomplete type" diagnostic.
+  typeof(foo(42)) invalid; // expected-error {{no matching function}}
+};
 }

--- a/clang/test/SemaCXX/recovery-type-cxx.cpp
+++ b/clang/test/SemaCXX/recovery-type-cxx.cpp
@@ -1,6 +1,6 @@
 // RUN: %clang_cc1 -triple=x86_64-unknown-unknown -frecovery-ast -frecovery-ast-type -o - %s -fsyntax-only -verify
 
-namespace NoCrash{
+namespace NoCrash {
 struct Indestructible {
   // Indestructible();
   ~Indestructible() = delete; // expected-note {{deleted}}
@@ -40,4 +40,19 @@ void test() { // expected-note {{candidate function}}
   // FIXME: suppress the init_conversion_failed diagnostic.
   int a = test(1); // expected-error {{no matching function}} expected-error {{cannot initialize a variable of type}}
 }
+}
+
+namespace enable_if_diags {
+template <int N> constexpr int templated() __attribute__((enable_if(N, ""))) {
+  return 1;
+}
+
+template <int N> constexpr int callTemplated() {
+  return templated<N>();  // expected-error {{no matching function for call to 'templated'}} 
+                          // expected-note@+5 {{in instantiation of function template specialization}}
+                          // expected-note@-7 {{candidate disabled}}
+}
+
+constexpr int B = 10 +  // expected-error {{constexpr variable 'B' must be initialized by a constant expression}}
+    callTemplated<0>(); // expected-note {{in call to 'callTemplated()'}} expected-note@-6 {{subexpression not valid in a constant expression}}
 }

--- a/clang/test/SemaCXX/recovery-type-cxx.cpp
+++ b/clang/test/SemaCXX/recovery-type-cxx.cpp
@@ -16,7 +16,21 @@ void test() {
 namespace {
 void foo(); // expected-note {{requires 0 arguments}}
 class Y {
-  // no "field has incomplete type" diagnostic.
+  // verify that "field has incomplete type" diagnostic is suppressed.
   typeof(foo(42)) invalid; // expected-error {{no matching function}}
 };
+}
+
+namespace {
+struct Incomplete; // expected-note 6{{forward declaration of}}
+Incomplete make_incomplete(); // expected-note 3{{declared here}}
+void test() {
+  // FIXME: suppress the "member access" diagnostic.
+  // FIXME：preserve the recovery-expr, right now clang drops them.
+  make_incomplete().a; // expected-error {{incomplete}} expected-error {{member access into}}
+  // FIXME: suppress the following "invalid application of 'sizeof'" diagnostic.
+  sizeof(make_incomplete()); // expected-error {{calling 'make_incomplete' with incomplete return type}} expected-error {{invalid application of 'sizeof'}}
+  // FIXME: suppress the "an incomplete type" diagnostic.
+  dynamic_cast<Incomplete&&>(make_incomplete()); // expected-error {{incomplete return type}} expected-error {{an incomplete type}}
+}
 }

--- a/clang/test/SemaCXX/recovery-type-cxx.cpp
+++ b/clang/test/SemaCXX/recovery-type-cxx.cpp
@@ -34,3 +34,10 @@ void test() {
   dynamic_cast<Incomplete&&>(make_incomplete()); // expected-error {{incomplete return type}} expected-error {{an incomplete type}}
 }
 }
+
+namespace Initializer {
+void test() { // expected-note {{candidate function}}
+  // FIXME: suppress the init_conversion_failed diagnostic.
+  int a = test(1); // expected-error {{no matching function}} expected-error {{cannot initialize a variable of type}}
+}
+}

--- a/clang/test/SemaCXX/recovery-type-cxx.cpp
+++ b/clang/test/SemaCXX/recovery-type-cxx.cpp
@@ -1,0 +1,14 @@
+// RUN: %clang_cc1 -triple=x86_64-unknown-unknown -frecovery-ast -frecovery-ast-type -std=c++11 -o - %s -fsyntax-only -verify
+
+namespace NoCrash{
+struct Indestructible {
+  // Indestructible();
+  ~Indestructible() = delete; // expected-note {{deleted}}
+};
+Indestructible make_indestructible();
+
+// no crash on HasSideEffect.
+void test() {
+  int s = sizeof(make_indestructible()); // expected-error {{deleted}}
+}
+}

--- a/clang/test/SemaTemplate/dependent-names.cpp
+++ b/clang/test/SemaTemplate/dependent-names.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsyntax-only -verify -std=c++11 %s 
+// RUN: %clang_cc1 -fsyntax-only -fno-recovery-ast-type -verify -std=c++11 %s
 
 typedef double A;
 template<typename T> class B {


### PR DESCRIPTION
This is an initial patch to preserve the type for recovery-expr, plan

- capture the type for broken function calls 
- create a cc1 flag, so that we can do it incrementally.
- fix all crashes, and add tests as cases start working

Failing tests (when turning on the `-recovery-ast`):

- [x] Clang :: AST/ast-dump-recovery.cpp
- [ ] Clang :: CXX/dcl.dcl/basic.namespace/namespace.udecl/p1.cpp
- [x] Clang :: CXX/dcl/dcl.fct/p17.cpp
- [ ] Clang :: CXX/over/over.match/over.match.best/p1-2a.cpp
- [x] Clang :: Index/getcursor-recovery.cpp
- [ ] Clang :: OpenMP/declare_reduction_messages.cpp
- [x] Clang :: Sema/invalid-member.cpp
- [ ] Clang :: SemaCUDA/function-overload.cu
- [ ] Clang :: SemaCXX/builtin-align-cxx.cpp
- [x] Clang :: SemaCXX/cxx1z-copy-omission.cpp (need a follow-up patch to improve diags)
- [x] Clang :: SemaCXX/enable_if.cpp (diagnostic behavior is changed)
- [x] Clang :: SemaTemplate/dependent-names.cpp (needs a follow-up to improve diags)
- [ ] Clang :: SemaTemplate/instantiate-function-params.cpp